### PR TITLE
Move gem configuration into a gemspec file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 require 'rake'
 require 'rubygems'
 require 'rdoc/task'
-require 'rubygems/package_task'
 
 $LOAD_PATH.unshift File.dirname(__FILE__) + '/lib'
 require 'upc'
@@ -27,36 +26,4 @@ Rake::RDocTask.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('MIT-LICENSE')
   rdoc.rdoc_files.include('CHANGELOG')
   rdoc.rdoc_files.include('lib/**/*.rb')
-end
-
-PKG_NAME           = "upc"
-PKG_VERSION        = UPC::Version::String
-PKG_FILE_NAME      = "#{PKG_NAME}-#{PKG_VERSION}"
-RUBY_FORGE_PROJECT = "yob-projects"
-
-spec = Gem::Specification.new do |s|
-  s.name              = PKG_NAME
-  s.version           = PKG_VERSION
-  s.summary           = "a (very) small library for working with Universal Product Codes"
-  s.description       = "a (very) small library for working with Universal Product Codes"
-  s.author            = "James Healy"
-  s.email             = "jimmy@deefa.com"
-  s.homepage          = "http://github.com/yob/upc/tree/master"
-  s.has_rdoc          = true
-  s.rdoc_options      << "--title" << "UPC" <<
-                        "--line-numbers"
-  s.rubyforge_project = RUBY_FORGE_PROJECT
-  s.test_files        = FileList["spec/**/*_spec.rb"]
-  s.files             = FileList[
-    "lib/**/*.rb",
-    "MIT-LICENSE",
-    "README.rdoc",
-    "CHANGELOG"
-  ]
-end
-
-Rake::PackageTask.new(spec) do |p|
-  p.version = PKG_VERSION
-  p.need_tar = false
-  p.need_zip = false
 end

--- a/upc.gemspec
+++ b/upc.gemspec
@@ -1,0 +1,20 @@
+Gem::Specification.new do |spec|
+  spec.name = "upc"
+  spec.version = "1.0.0"
+  spec.summary = "a (very) small library for working with Universal Product Codes"
+  spec.description = "a (very) small library for working with Universal Product Codes"
+  spec.license = "MIT"
+  spec.author = "James Healy"
+  spec.email = "jimmy@deefa.com"
+  spec.homepage = "http://github.com/yob/upc"
+  spec.has_rdoc = true
+  spec.rdoc_options << "--title" << "UPC" << "--line-numbers"
+
+  spec.required_ruby_version = ">=1.9.3"
+
+  spec.test_files = Dir.glob("spec/**/*_spec.rb")
+  spec.files = Dir.glob("lib/**/*.rb") + ["MIT-LICENSE", "README.rdoc", "CHANGELOG" ]
+
+  spec.add_development_dependency("rake")
+  spec.add_development_dependency("rspec", "~> 3.0")
+end


### PR DESCRIPTION
Will allow this lib to be loaded by a git reference in bundler, plus easy gem building with `gem build upc.gemspec`